### PR TITLE
fix: fixing comparsion of two arguments when in spec is empty

### DIFF
--- a/internal/rabbitmqclient/utilities.go
+++ b/internal/rabbitmqclient/utilities.go
@@ -81,6 +81,9 @@ func ConvertInterfaceMapToStringMap(m map[string]interface{}) map[string]string 
 
 // MapsEqualJSON compares two maps
 func MapsEqualJSON(m1, m2 map[string]string) (bool, error) {
+	if m1 == nil {
+		m1 = map[string]string{}
+	}
 	json1, err := json.Marshal(m1)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
